### PR TITLE
Use "bukkitScheduler::runTask" instead of the async version

### DIFF
--- a/src/main/kotlin/com/okkero/skedule/BukkitDispatcher.kt
+++ b/src/main/kotlin/com/okkero/skedule/BukkitDispatcher.kt
@@ -24,7 +24,7 @@ class BukkitDispatcher(val plugin: Plugin, val async: Boolean = false) : Corouti
         get() = if (async) {
             bukkitScheduler::runTaskAsynchronously
         } else {
-            bukkitScheduler::runTaskAsynchronously
+            bukkitScheduler::runTask
         }
 
     @InternalCoroutinesApi


### PR DESCRIPTION
As of now, calling "runTask" would use the async method provided by the Bukkit scheduler ignoring if the dispatcher is sync or async.

I don't know if the change in ee58a8f7b572137b3529bad9f3926d070ad03817 was deliberate, but otherwise this doesn't make any sense